### PR TITLE
lib: reverse left lane boundary

### DIFF
--- a/lib/opendrive/lanes.py
+++ b/lib/opendrive/lanes.py
@@ -296,11 +296,13 @@ class LaneSection:
 
 
   def process_lane(self, reference_line):
-    left_boundary = reference_line
+    left_boundary = reference_line.copy()
+    # The left lane is opposite to the reference line
+    left_boundary.reverse()
     for lane in self.left[::-1]:
       left_boundary = lane.generate_boundary(left_boundary)
 
-    left_boundary = reference_line
+    left_boundary = reference_line.copy()
     for lane in self.right:
       left_boundary = lane.generate_boundary(left_boundary)
 


### PR DESCRIPTION
The left lane is opposite to the reference line, so we have to reverse left lane boundary.

1. But we still have to deal with `s` reverse.