### PR TITLE
fix: fix _draw_polygon() can't draw crosswalk correctly

### DIFF
--- a/imap/map.py
+++ b/imap/map.py
@@ -141,12 +141,11 @@ class Map:
 
     @staticmethod
     def _draw_polygon(polygon, ax, color_val):
-        # todo(zero): need to fix
         pxy = []
         for point in polygon.point:
             pxy.append([point.x, point.y])
-        polygon = Polygon(pxy, True)
-        ax.add_patch(polygon)
+        patch = Polygon(pxy, closed=True, edgecolor=color_val)
+        ax.add_patch(patch)
 
     @staticmethod
     def _draw_stop_line(line_segment, ax, color_val):


### PR DESCRIPTION
Fixed a bug in the `_draw_polygon()` function of `map.py` when drawing polygons for crosswalks on the HD map.

> Before Fix:

<img width="1081" alt="image" src="https://github.com/user-attachments/assets/7134bfb5-83e4-4899-ac8e-f1bcc6709953" />


> After Fix:

<img width="897" alt="image" src="https://github.com/user-attachments/assets/0172c559-a6f8-4cf6-a45f-d802c74248c3" />
